### PR TITLE
switch to coqui STT

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-deepspeech = "*"
+stt = "*"
 numpy = "*"
 pyyaml = "*"
 aiohttp = "*"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+UPDATE:
+=======
+This version works with Coqui's STT, the spiritual successor to DeepSpeech.
+
+
 An aiohttp stream server for DeepSpeech
 =======================================
 

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 from aiohttp import web
-import deepspeech
+import stt
 import numpy
 import yaml
 import time
@@ -22,10 +22,10 @@ def load_config():
         return yaml.safe_load(f)
 
 def create_model(config):
-    d = config['deepspeech']
-    model = deepspeech.Model(d['model'])
+    d = config['stt']
+    model = stt.Model(d['model'])
     model.setBeamWidth(int(d.get('beam_width', '512')))
-    model.enableExternalScorer(d.get('scorer','models/deepspeech-0.7.0-models.scorer'))
+    model.enableExternalScorer(d.get('scorer','models/coqui-v1.0.0-huge-vocab/huge-vocabulary.scorer'))
     if 'scorer_alpha' in d and 'scorer_beta' in d:
         model.setScorerAlphaBeta(float(d.get('scorer_alpha')),float(d.get('scorer_beta')))
     

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
-deepspeech:
-  model: models/deepspeech-0.7.0-models.pbmm
-  scorer: models/deepspeech-0.7.0-models.scorer
+stt:
+  model: models/coqui-v1.0.0-huge-vocab/model.tflite
+  scorer: models/coqui-v1.0.0-huge-vocab/huge-vocabulary.scorer
   beam_width: 512
 server:
   host: '0.0.0.0'


### PR DESCRIPTION
First of all, thanks a lot for coding this up! It's sped up my mycroft interactions considerably 👍 

Since DeepSpeech is deprecated and coqui's `stt` is its intellectual successor it makes sense to migrate your excellent server to that package. 
I've been using this successfully on my RPI4 for a while now.